### PR TITLE
Fix bug with zero 'max_active_applicants' parameter

### DIFF
--- a/src/hiring/opening.rs
+++ b/src/hiring/opening.rs
@@ -86,6 +86,7 @@ where
         current_block_height: BlockNumber,
         activate_at: ActivateOpeningAt<BlockNumber>,
         runtime_minimum_balance: Balance,
+        application_rationing_policy: Option<ApplicationRationingPolicy>,
         application_staking_policy: Option<StakingPolicy<Balance, BlockNumber>>,
         role_staking_policy: Option<StakingPolicy<Balance, BlockNumber>>,
     ) -> Result<(), AddOpeningError> {
@@ -97,6 +98,13 @@ where
             },
             AddOpeningError::OpeningMustActivateInTheFuture
         );
+
+        if let Some(app_rationing_policy) = application_rationing_policy {
+            ensure!(
+                app_rationing_policy.max_active_applicants > 0,
+                AddOpeningError::ApplicationRationingZeroMaxApplicants
+            );
+        }
 
         // Check that staking amounts clear minimum balance required.
         StakingPolicy::ensure_amount_valid_in_opt_staking_policy(
@@ -228,6 +236,10 @@ pub enum AddOpeningError {
     /// It is not possible to stake less than the minimum balance defined in the
     /// `Currency` module.
     StakeAmountLessThanMinimumCurrencyBalance(StakePurpose),
+
+    /// It is not possible to provide application rationing policy with zero
+    /// 'max_active_applicants' parameter.
+    ApplicationRationingZeroMaxApplicants,
 }
 
 /// The possible outcome for an application in an opening which is being filled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,7 @@ impl<T: Trait> Module<T> {
             current_block_height,
             activate_at.clone(),
             T::Currency::minimum_balance(),
+            application_rationing_policy.clone(),
             application_staking_policy.clone(),
             role_staking_policy.clone(),
         )?;

--- a/src/test/add_opening.rs
+++ b/src/test/add_opening.rs
@@ -166,3 +166,15 @@ fn add_opening_succeeds_or_fails_due_to_role_staking_policy() {
         ));
     });
 }
+
+#[test]
+fn add_opening_succeeds_or_fails_due_to_invalid_application_rationing_policy() {
+    build_test_externalities().execute_with(|| {
+        let mut opening_data = AddOpeningFixture::default();
+        opening_data.application_rationing_policy = Some(ApplicationRationingPolicy {
+            max_active_applicants: 0,
+        });
+
+        opening_data.call_and_assert(Err(AddOpeningError::ApplicationRationingZeroMaxApplicants));
+    });
+}


### PR DESCRIPTION
Changes:
- introduce new AddOpeningError enum entry - ApplicationRationingZeroMaxApplicants
- add check to ensure_can_add_opening()
- cover new logic with test

This PR will break upstream module https://github.com/bedeho/substrate-runtime-joystream/tree/add-content-wg.