### PR TITLE
do not unstake role stake for successful applicants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1130,14 +1130,19 @@ impl<T: Trait> Module<T> {
     ) -> ApplicationDeactivationInitationResult {
         match application.stage {
             ApplicationStage::Active => {
-                // Initiate unstaking of any active stake for the application or the role.
+                // Initiate unstaking of any active application stake
                 let was_unstaked = Self::opt_infallible_unstake(
-                    application.active_role_staking_id,
-                    role_stake_unstaking_period,
-                ) || Self::opt_infallible_unstake(
                     application.active_application_staking_id,
                     application_stake_unstaking_period,
                 );
+
+                // Only unstake role stake for a non successful result ie. not Hired
+                if cause != hiring::ApplicationDeactivationCause::Hired {
+                    Self::opt_infallible_unstake(
+                        application.active_role_staking_id,
+                        role_stake_unstaking_period,
+                    );
+                }
 
                 // Grab current block height
                 let current_block_height = <system::Module<T>>::block_number();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1131,18 +1131,23 @@ impl<T: Trait> Module<T> {
         match application.stage {
             ApplicationStage::Active => {
                 // Initiate unstaking of any active application stake
-                let was_unstaked = Self::opt_infallible_unstake(
+                let application_was_unstaked = Self::opt_infallible_unstake(
                     application.active_application_staking_id,
                     application_stake_unstaking_period,
                 );
 
                 // Only unstake role stake for a non successful result ie. not Hired
-                if cause != hiring::ApplicationDeactivationCause::Hired {
+                let role_was_unstaked = if cause != hiring::ApplicationDeactivationCause::Hired {
                     Self::opt_infallible_unstake(
                         application.active_role_staking_id,
                         role_stake_unstaking_period,
-                    );
-                }
+                    )
+                } else {
+                    false
+                };
+
+                // Capture if any unstaking occured at all
+                let was_unstaked = application_was_unstaked || role_was_unstaked;
 
                 // Grab current block height
                 let current_block_height = <system::Module<T>>::block_number();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1137,14 +1137,11 @@ impl<T: Trait> Module<T> {
                 );
 
                 // Only unstake role stake for a non successful result ie. not Hired
-                let role_was_unstaked = if cause != hiring::ApplicationDeactivationCause::Hired {
-                    Self::opt_infallible_unstake(
+                let role_was_unstaked = cause != hiring::ApplicationDeactivationCause::Hired
+                    && Self::opt_infallible_unstake(
                         application.active_role_staking_id,
                         role_stake_unstaking_period,
-                    )
-                } else {
-                    false
-                };
+                    );
 
                 // Capture if any unstaking occured at all
                 let was_unstaked = application_was_unstaked || role_was_unstaked;


### PR DESCRIPTION
Fix `try_to_initiate_application_deactivation()` to ensure only unsuccessful applicants unstake their role stake.