### PR TITLE
Combined test and mock branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ srml-support-procedural = { package = 'srml-support-procedural', git = 'https://
 system = { package = 'srml-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3'}
 balances = { package = 'srml-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3'}
 codec = { package = 'parity-scale-codec', version = '1.0.0', default-features = false, features = ['derive'] }
+mockall = {version = "0.6.0", optional = true}
 
 [dependencies.stake]
 default_features = false
@@ -37,9 +38,12 @@ rev = '0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3'
 [dev-dependencies]
 runtime-io = { package = 'sr-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3'}
 primitives = { package = 'substrate-primitives', git = 'https://github.com/paritytech/substrate.git', rev = '0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3'}
+mockall = "0.6.0"
+
 
 [features]
 default = ['std']
+test = ['mockall']
 std = [
 	'serde',
 	'serde_derive',
@@ -51,5 +55,5 @@ std = [
 	'system/std',
   	'balances/std',
 	'timestamp/std',
-	'stake/std'
+	'stake/std',
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
-#![cfg_attr(test, feature(proc_macro_hygiene))]
 
 // Test feature dependencies
 #[cfg(all(any(test, feature = "test"), not(target_arch = "wasm32")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,17 @@
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
+// Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
+#![cfg_attr(test, feature(proc_macro_hygiene))]
+
+// Test feature dependencies
+#[cfg(all(any(test, feature = "test"), not(target_arch = "wasm32")))]
+use mockall::predicate::*;
+#[cfg(all(any(test, feature = "test"), not(target_arch = "wasm32")))]
+use mockall::*;
+
+use stake::{InitiateUnstakingError, Stake, StakeActionError, StakingError, Trait as StakeTrait};
 
 use codec::Codec;
 use system;
@@ -30,6 +40,9 @@ use rstd::collections::btree_map::BTreeMap;
 use rstd::collections::btree_set::BTreeSet;
 use rstd::iter::Iterator;
 use rstd::prelude::*;
+
+use rstd::cell::RefCell;
+use rstd::rc::Rc;
 
 use crate::sr_api_hidden_includes_decl_storage::hidden_include::traits::Imbalance;
 
@@ -66,6 +79,9 @@ pub trait Trait: system::Trait + stake::Trait + Sized {
 
     /// Type that will handle various staking events
     type ApplicationDeactivatedHandler: ApplicationDeactivatedHandler<Self>;
+
+    /// Marker type for Stake module handler. Indicates that hiring module uses stake module mock.
+    type StakeHandlerProvider: StakeHandlerProvider<Self>;
 }
 
 decl_storage! {
@@ -85,7 +101,6 @@ decl_storage! {
 
         /// Internal purpose of given stake, i.e. fro what application, and whether for the role or for the application.
         pub ApplicationIdByStakingId get(stake_purpose_by_staking_id): linked_map T::StakeId => T::ApplicationId;
-
     }
 }
 
@@ -619,7 +634,7 @@ impl<T: Trait> Module<T> {
 
             assert_ne!(
                 deactivation_result,
-                ApplicationDeactivationInitationResult::Ignored
+                ApplicationDeactivationInitiationResult::Ignored
             );
         }
 
@@ -742,7 +757,7 @@ impl<T: Trait> Module<T> {
             hiring::ApplicationDeactivationCause::External,
         );
 
-        assert_ne!(result, ApplicationDeactivationInitationResult::Ignored);
+        assert_ne!(result, ApplicationDeactivationInitiationResult::Ignored);
 
         // DONE
         Ok(())
@@ -938,6 +953,7 @@ pub type NegativeImbalance<T> =
  *  ======== ======== ======== ======== =======
  */
 
+#[derive(PartialEq, Debug, Clone)]
 struct ApplicationsDeactivationsInitiationResult {
     number_of_unstaking_applications: u32,
     number_of_deactivated_applications: u32,
@@ -952,9 +968,9 @@ type ApplicationBTreeMap<T> = BTreeMap<
     >,
 >;
 
-#[derive(PartialEq, Debug)]
-enum ApplicationDeactivationInitationResult {
-    Ignored, // <= is there a case for kicking this out, making sure that initation cannot happen when it may fail?
+#[derive(PartialEq, Debug, Clone)]
+enum ApplicationDeactivationInitiationResult {
+    Ignored, // <= is there a case for kicking this out, making sure that initiation cannot happen when it may fail?
     Unstaking,
     Deactivated,
 }
@@ -1054,7 +1070,7 @@ impl<T: Trait> Module<T> {
         applications
             .iter()
             .map(
-                |(application_id, application)| -> ApplicationDeactivationInitationResult {
+                |(application_id, application)| -> ApplicationDeactivationInitiationResult {
                     // Initiate deactivations!
                     Self::try_to_initiate_application_deactivation(
                         application,
@@ -1074,9 +1090,9 @@ impl<T: Trait> Module<T> {
                 |acc, deactivation_result| {
                     // Update accumulator counters based on what actually happened
                     match deactivation_result {
-                        ApplicationDeactivationInitationResult::Ignored => acc,
+                        ApplicationDeactivationInitiationResult::Ignored => acc,
 
-                        ApplicationDeactivationInitationResult::Unstaking => {
+                        ApplicationDeactivationInitiationResult::Unstaking => {
                             ApplicationsDeactivationsInitiationResult {
                                 number_of_unstaking_applications: 1 + acc
                                     .number_of_unstaking_applications,
@@ -1085,7 +1101,7 @@ impl<T: Trait> Module<T> {
                             }
                         }
 
-                        ApplicationDeactivationInitationResult::Deactivated => {
+                        ApplicationDeactivationInitiationResult::Deactivated => {
                             ApplicationsDeactivationsInitiationResult {
                                 number_of_unstaking_applications: acc
                                     .number_of_unstaking_applications,
@@ -1105,7 +1121,7 @@ impl<T: Trait> Module<T> {
         application_stake_unstaking_period: Option<T::BlockNumber>,
         role_stake_unstaking_period: Option<T::BlockNumber>,
         cause: hiring::ApplicationDeactivationCause,
-    ) -> ApplicationDeactivationInitationResult {
+    ) -> ApplicationDeactivationInitiationResult {
         match application.stage {
             ApplicationStage::Active => {
                 // Initiate unstaking of any active application stake
@@ -1200,18 +1216,17 @@ impl<T: Trait> Module<T> {
 
                 // Return conclusion
                 if was_unstaked {
-                    ApplicationDeactivationInitationResult::Unstaking
+                    ApplicationDeactivationInitiationResult::Unstaking
                 } else {
-                    ApplicationDeactivationInitationResult::Deactivated
+                    ApplicationDeactivationInitiationResult::Deactivated
                 }
             }
-            _ => ApplicationDeactivationInitationResult::Ignored,
+            _ => ApplicationDeactivationInitiationResult::Ignored,
         }
     }
 
     /// Tries to unstake, based on a stake id which, if set, MUST
     /// be ready to be unstaked, with an optional unstaking period.
-    ///
     ///
     /// Returns whether unstaking was actually initiated.
     fn opt_infallible_unstake(
@@ -1222,9 +1237,9 @@ impl<T: Trait> Module<T> {
             // `initiate_unstaking` MUST hold, is runtime invariant, false means code is broken.
             // But should we do panic in runtime? Is there safer way?
 
-            assert!(
-                <stake::Module<T>>::initiate_unstaking(&stake_id, opt_unstaking_period).is_ok()
-            );
+            assert!(T::StakeHandlerProvider::staking()
+                .initiate_unstaking(&stake_id, opt_unstaking_period)
+                .is_ok());
         }
 
         opt_stake_id.is_some()
@@ -1252,7 +1267,7 @@ impl<T: Trait> Module<T> {
         application_id: &T::ApplicationId,
     ) -> T::StakeId {
         // Create stake
-        let new_stake_id = <stake::Module<T>>::create_stake();
+        let new_stake_id = T::StakeHandlerProvider::staking().create_stake();
 
         // Keep track of this stake id to process unstaking callbacks that may
         // be invoked later.
@@ -1269,7 +1284,10 @@ impl<T: Trait> Module<T> {
         //
         // MUST work, is runtime invariant, false means code is broken.
         // But should we do panic in runtime? Is there safer way?
-        assert_eq!(<stake::Module<T>>::stake(&new_stake_id, imbalance), Ok(()));
+        assert_eq!(
+            T::StakeHandlerProvider::staking().stake(&new_stake_id, imbalance),
+            Ok(())
+        );
 
         new_stake_id
     }
@@ -1279,7 +1297,7 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> Module<T> {
     /// Evaluates prospects for a new application
     ///
-    fn would_application_get_added(
+    pub(crate) fn would_application_get_added(
         possible_opening_application_rationing_policy: &Option<ApplicationRationingPolicy>,
         opening_applicants: &BTreeSet<T::ApplicationId>,
         opt_role_stake_balance: &Option<BalanceOf<T>>,
@@ -1362,9 +1380,9 @@ impl<T: Trait> Module<T> {
     fn get_opt_stake_amount(stake_id: Option<T::StakeId>) -> BalanceOf<T> {
         stake_id.map_or(<BalanceOf<T> as Zero>::zero(), |stake_id| {
             // INVARIANT: stake MUST exist in the staking module
-            assert!(<stake::Stakes<T>>::exists(stake_id));
+            assert!(T::StakeHandlerProvider::staking().stake_exists(stake_id));
 
-            let stake = <stake::Stakes<T>>::get(stake_id);
+            let stake = T::StakeHandlerProvider::staking().get_stake(stake_id);
 
             match stake.staking_status {
                 // INVARIANT: stake MUST be in the staked state.
@@ -1374,7 +1392,7 @@ impl<T: Trait> Module<T> {
         })
     }
 
-    fn create_stake_balance(
+    pub(crate) fn create_stake_balance(
         opt_stake_imbalance: &Option<NegativeImbalance<T>>,
     ) -> Option<BalanceOf<T>> {
         if let Some(ref imbalance) = opt_stake_imbalance {
@@ -1382,5 +1400,120 @@ impl<T: Trait> Module<T> {
         } else {
             None
         }
+    }
+}
+
+/*
+ *  === Stake module wrappers  ======
+ */
+
+/// Defines stake module interface
+#[cfg_attr(
+    all(any(test, feature = "test"), not(target_arch = "wasm32")),
+    automock
+)]
+pub trait StakeHandler<T: StakeTrait> {
+    /// Adds a new Stake which is NotStaked, created at given block, into stakes map.
+    fn create_stake(&self) -> T::StakeId;
+
+    /// to the module's account, and the corresponding staked_balance is set to this amount in the new Staked state.
+    /// On error, as the negative imbalance is not returned to the caller, it is the caller's responsibility to return the funds
+    /// back to the source (by creating a new positive imbalance)
+    fn stake(
+        &self,
+        new_stake_id: &T::StakeId,
+        imbalance: NegativeImbalance<T>,
+    ) -> Result<(), StakeActionError<stake::StakingError>>;
+
+    /// Checks whether stake exists by its id
+    fn stake_exists(&self, stake_id: T::StakeId) -> bool;
+
+    /// Acquires stake by id
+    fn get_stake(&self, stake_id: T::StakeId) -> Stake<T::BlockNumber, BalanceOf<T>, T::SlashId>;
+
+    /// Initiate unstaking of a Staked stake.
+    fn initiate_unstaking(
+        &self,
+        stake_id: &T::StakeId,
+        unstaking_period: Option<T::BlockNumber>,
+    ) -> Result<(), StakeActionError<InitiateUnstakingError>>;
+}
+
+/// Allows to provide different StakeHandler implementation. Useful for mocks.
+pub trait StakeHandlerProvider<T: Trait> {
+    /// Returns StakeHandler. Mock entry point for stake module.
+    fn staking() -> Rc<RefCell<dyn StakeHandler<T>>>;
+}
+
+impl<T: Trait> StakeHandlerProvider<T> for Module<T> {
+    /// Returns StakeHandler. Mock entry point for stake module.
+    fn staking() -> Rc<RefCell<dyn StakeHandler<T>>> {
+        Rc::new(RefCell::new(HiringStakeHandler {}))
+    }
+}
+
+/// Default stake module logic implementation
+pub struct HiringStakeHandler;
+impl<T: Trait> StakeHandler<T> for HiringStakeHandler {
+    fn create_stake(&self) -> T::StakeId {
+        <stake::Module<T>>::create_stake()
+    }
+
+    fn stake(
+        &self,
+        new_stake_id: &T::StakeId,
+        imbalance: NegativeImbalance<T>,
+    ) -> Result<(), StakeActionError<StakingError>> {
+        <stake::Module<T>>::stake(new_stake_id, imbalance)
+    }
+
+    fn stake_exists(&self, stake_id: T::StakeId) -> bool {
+        <stake::Stakes<T>>::exists(stake_id)
+    }
+
+    fn get_stake(&self, stake_id: T::StakeId) -> Stake<T::BlockNumber, BalanceOf<T>, T::SlashId> {
+        <stake::Stakes<T>>::get(stake_id)
+    }
+
+    fn initiate_unstaking(
+        &self,
+        stake_id: &T::StakeId,
+        unstaking_period: Option<T::BlockNumber>,
+    ) -> Result<(), StakeActionError<InitiateUnstakingError>> {
+        <stake::Module<T>>::initiate_unstaking(&stake_id, unstaking_period)
+    }
+}
+
+// Proxy implementation of StakeHandler trait to simplify calls via staking() method
+// Allows to get rid of borrow() calls,
+// eg.: T::StakeHandlerProvider::staking().get_stake(stake_id);
+// instead of T::StakeHandlerProvider::staking().borrow().get_stake(stake_id);
+impl<T: Trait> StakeHandler<T> for Rc<RefCell<dyn StakeHandler<T>>> {
+    fn create_stake(&self) -> T::StakeId {
+        self.borrow().create_stake()
+    }
+
+    fn stake(
+        &self,
+        new_stake_id: &T::StakeId,
+        imbalance: NegativeImbalance<T>,
+    ) -> Result<(), StakeActionError<StakingError>> {
+        self.borrow().stake(new_stake_id, imbalance)
+    }
+
+    fn stake_exists(&self, stake_id: T::StakeId) -> bool {
+        self.borrow().stake_exists(stake_id)
+    }
+
+    fn get_stake(&self, stake_id: T::StakeId) -> Stake<T::BlockNumber, BalanceOf<T>, T::SlashId> {
+        self.borrow().get_stake(stake_id)
+    }
+
+    fn initiate_unstaking(
+        &self,
+        stake_id: &T::StakeId,
+        unstaking_period: Option<T::BlockNumber>,
+    ) -> Result<(), StakeActionError<InitiateUnstakingError>> {
+        self.borrow().initiate_unstaking(stake_id, unstaking_period)
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -8,9 +8,15 @@ use runtime_primitives::{
 };
 use srml_support::{impl_outer_origin, parameter_types};
 
+use crate::hiring::ApplicationDeactivationCause;
 use crate::{Module, Trait};
 use balances;
 use stake;
+
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::panic;
+use std::rc::Rc;
 
 impl_outer_origin! {
     pub enum Origin for Test {}
@@ -78,7 +84,9 @@ impl Trait for Test {
 
     type ApplicationId = u64;
 
-    type ApplicationDeactivatedHandler = ();
+    type ApplicationDeactivatedHandler = TestApplicationDeactivatedHandler;
+
+    type StakeHandlerProvider = TestStakeHandlerProvider;
 }
 
 impl stake::Trait for Test {
@@ -89,7 +97,58 @@ impl stake::Trait for Test {
     type SlashId = u64;
 }
 
-pub(crate) fn build_test_externalities() -> runtime_io::TestExternalities {
+pub type Balances = balances::Module<Test>;
+pub type Hiring = Module<Test>;
+
+// Intercepts panic method
+// Returns: whether panic occurred
+fn panics<F: std::panic::RefUnwindSafe + Fn()>(could_panic_func: F) -> bool {
+    {
+        let default_hook = panic::take_hook();
+        panic::set_hook(Box::new(|info| {
+            println!("{}", info);
+        }));
+
+        // intercept panic
+        let result = panic::catch_unwind(|| could_panic_func());
+
+        //restore default behaviour
+        panic::set_hook(default_hook);
+
+        result.is_err()
+    }
+}
+
+pub struct TestStakeHandlerProvider;
+impl crate::StakeHandlerProvider<Test> for TestStakeHandlerProvider {
+    /// Returns StakeHandler. Mock entry point for stake module.
+    fn staking() -> Rc<RefCell<dyn crate::StakeHandler<Test>>> {
+        THREAD_LOCAL_STAKE_HANDLER.with(|f| f.borrow().clone())
+    }
+}
+
+// 1. RefCell - thread_local! mutation pattern
+// 2. Rc - ability to have multiple references
+// 3. Refcell - interior mutability to provide extra-mock capabilities (like mockall checkpoint).
+thread_local! {
+    pub static THREAD_LOCAL_STAKE_HANDLER:
+      RefCell<Rc<RefCell<dyn crate::StakeHandler<Test>>>> = RefCell::new(Rc::new(RefCell::new(crate::HiringStakeHandler {})));
+}
+
+// Sets stake handler implementation in hiring module. Mockall frameworks integration
+pub(crate) fn set_stake_handler_impl(mock: Rc<rstd::cell::RefCell<dyn crate::StakeHandler<Test>>>) {
+    // Hiring::staking.mock_safe(move || MockResult::Return(mock.clone()));
+    THREAD_LOCAL_STAKE_HANDLER.with(|f| {
+        *f.borrow_mut() = mock.clone();
+    });
+}
+
+// Tests mock expectation and restores default behaviour
+pub(crate) fn test_expectation_and_clear_mock() {
+    set_stake_handler_impl(Rc::new(RefCell::new(crate::HiringStakeHandler {})));
+}
+
+pub fn build_test_externalities() -> runtime_io::TestExternalities {
     let t = system::GenesisConfig::default()
         .build_storage::<Test>()
         .unwrap();
@@ -97,6 +156,48 @@ pub(crate) fn build_test_externalities() -> runtime_io::TestExternalities {
     t.into()
 }
 
-pub type Balances = balances::Module<Test>;
-pub type Hiring = Module<Test>;
-pub type System = system::Module<Test>;
+// Intercepts panic in provided function, test mock expectation and restores default behaviour
+pub(crate) fn handle_mock<F: std::panic::RefUnwindSafe + Fn()>(func: F) {
+    let panicked = panics(func);
+
+    test_expectation_and_clear_mock();
+
+    assert!(!panicked);
+}
+
+//
+// ******* ApplicationDeactivatedHandler mocks ********************
+//
+thread_local! {
+    pub static LAST_DEACTIVATED_APPLICATION:
+        Cell<Option<(<Test as Trait>::ApplicationId, ApplicationDeactivationCause)>> = Cell::new(None);
+}
+
+pub struct TestApplicationDeactivatedHandler;
+impl crate::ApplicationDeactivatedHandler<Test> for TestApplicationDeactivatedHandler {
+    fn deactivated(
+        application_id: &<Test as Trait>::ApplicationId,
+        cause: ApplicationDeactivationCause,
+    ) {
+        LAST_DEACTIVATED_APPLICATION.with(|f| {
+            f.replace(Some((*application_id, cause)));
+        });
+    }
+}
+
+impl TestApplicationDeactivatedHandler {
+    pub(crate) fn assert_deactivated_application(
+        expected_application_id: <Test as Trait>::ApplicationId,
+        expected_cause: ApplicationDeactivationCause,
+    ) {
+        let mut actual_deactivated_application = None;
+        LAST_DEACTIVATED_APPLICATION.with(|f| {
+            actual_deactivated_application = f.replace(None);
+        });
+
+        assert_eq!(
+            Some((expected_application_id, expected_cause)),
+            actual_deactivated_application
+        );
+    }
+}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -98,6 +98,7 @@ impl stake::Trait for Test {
 }
 
 pub type Balances = balances::Module<Test>;
+pub type System = system::Module<Test>;
 pub type Hiring = Module<Test>;
 
 // Intercepts panic method

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,20 +1,17 @@
 #![cfg(test)]
 
-
-mod add_application;
-mod add_opening;
-mod begin_accepting_applications;
-mod begin_review;
-mod cancel_opening;
-mod deactivate_application;
-mod ensure_can_add_application;
-mod fill_opening;
-mod on_finalize;
+mod public_api;
 mod smoke;
-mod unstaked;
+mod staking_module;
+use public_api::*;
 
-use super::*;
 use crate::mock::Test;
+use crate::*;
+
+use rstd::cell::RefCell;
+use rstd::rc::Rc;
+
+use std::panic;
 
 pub(crate) type OpeningId = <Test as Trait>::OpeningId;
 pub(crate) type ApplicationId = <Test as Trait>::ApplicationId;
@@ -23,7 +20,7 @@ pub(crate) type StakeId = <Test as stake::Trait>::StakeId;
 pub(crate) type Balance =
     <<Test as stake::Trait>::Currency as Currency<<Test as system::Trait>::AccountId>>::Balance;
 
-//Debug test object content. Recurring temporary usage - do not delete.
+// Debug test object content. Recurring temporary usage - do not delete.
 #[allow(dead_code)]
 pub fn debug_print<T: rstd::fmt::Debug>(obj: T) {
     println!("{:?}", obj);

--- a/src/test/public_api/add_opening.rs
+++ b/src/test/public_api/add_opening.rs
@@ -1,15 +1,10 @@
-use super::*;
 use crate::mock::*;
+use crate::test::*;
 use crate::StakingAmountLimitMode::Exact;
 use rstd::collections::btree_set::BTreeSet;
 
 static FIRST_BLOCK_HEIGHT: <Test as system::Trait>::BlockNumber = 1;
 pub static HUMAN_READABLE_TEXT: &[u8] = b"HUMAN_READABLE_TEXT!!!!";
-
-/*
-Not covered:
-- ApplicationRationingPolicy (no ensures yet in add_opening)
-*/
 
 pub struct AddOpeningFixture<Balance> {
     pub activate_at: ActivateOpeningAt<BlockNumber>,

--- a/src/test/public_api/begin_accepting_applications.rs
+++ b/src/test/public_api/begin_accepting_applications.rs
@@ -1,8 +1,6 @@
-use super::*;
 use crate::mock::*;
+use crate::test::*;
 use rstd::collections::btree_set::BTreeSet;
-
-use add_opening::AddOpeningFixture;
 
 #[test]
 fn begin_accepting_applications_fails_with_no_opening() {
@@ -58,7 +56,7 @@ fn begin_accepting_applications_succeeds() {
             application_rationing_policy: None,
             application_staking_policy: None,
             role_staking_policy: None,
-            human_readable_text: add_opening::HUMAN_READABLE_TEXT.to_vec(),
+            human_readable_text: HUMAN_READABLE_TEXT.to_vec(),
         };
 
         assert_eq!(updated_opening, expected_opening_state);

--- a/src/test/public_api/begin_review.rs
+++ b/src/test/public_api/begin_review.rs
@@ -1,13 +1,5 @@
-use super::*;
 use crate::mock::*;
-use rstd::collections::btree_set::BTreeSet;
-
-use add_opening::AddOpeningFixture;
-
-/*
-Not covered:
-- opening has applications
-*/
+use crate::test::*;
 
 #[test]
 fn begin_review_fails_with_no_opening() {
@@ -43,29 +35,20 @@ fn begin_review_succeeds() {
 
         let add_opening_result = opening_fixture.add_opening();
         let opening_id = add_opening_result.unwrap();
+        let application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        assert!(application_fixture.add_application().is_ok());
+
+        let old_opening = <OpeningById<Test>>::get(opening_id);
 
         assert_eq!(Hiring::begin_review(opening_id), Ok(()));
 
         let updated_opening = <OpeningById<Test>>::get(opening_id);
 
-        let expected_opening_state = Opening {
-            created: 1,
-            stage: OpeningStage::Active {
-                stage: ActiveOpeningStage::ReviewPeriod {
-                    started_accepting_applicants_at_block: 1,
-                    started_review_period_at_block: 1,
-                },
-                applications_added: BTreeSet::new(),
-                active_application_count: 0,
-                unstaking_application_count: 0,
-                deactivated_application_count: 0,
-            },
-            max_review_period_length: 672,
-            application_rationing_policy: None,
-            application_staking_policy: None,
-            role_staking_policy: None,
-            human_readable_text: add_opening::HUMAN_READABLE_TEXT.to_vec(),
-        };
+        let expected_opening_state =
+            old_opening.clone_with_new_active_opening_stage(ActiveOpeningStage::ReviewPeriod {
+                started_accepting_applicants_at_block: 1,
+                started_review_period_at_block: 1,
+            });
 
         assert_eq!(updated_opening, expected_opening_state);
     });

--- a/src/test/public_api/cancel_opening.rs
+++ b/src/test/public_api/cancel_opening.rs
@@ -1,19 +1,12 @@
-use super::*;
 use crate::mock::*;
+use crate::test::*;
 
-use add_application::AddApplicationFixture;
-use add_opening::AddOpeningFixture;
-
+use crate::test::public_api::*;
 use rstd::collections::btree_map::BTreeMap;
 
 /*
 Not covered:
 - Application content check
-- ApplicationDeactivatedHandler
-
-- staking state checks:
-i.application.active_role_staking_id;
-ii.application.active_application_staking_id;
 */
 
 pub struct CancelOpeningFixture {
@@ -235,6 +228,7 @@ fn cancel_opening_succeeds_with_single_unstaking_application() {
         }));
     });
 }
+
 #[test]
 fn cancel_opening_succeeds_with_single_deactivated_application() {
     build_test_externalities().execute_with(|| {
@@ -356,5 +350,82 @@ fn cancel_opening_fails_due_to_too_short_role_unstaking_period() {
         cancel_opening_fixture.call_and_assert(Err(CancelOpeningError::UnstakingPeriodTooShort(
             StakePurpose::Role,
         )));
+    });
+}
+
+#[test]
+fn cancel_opening_succeeds_with_single_unstaking_application_with_application_stake_checks() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = default_mock_for_creating_stake();
+            set_stake_handler_impl(mock.clone());
+
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.application_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_application_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let mock2 = default_mock_for_unstaking();
+            set_stake_handler_impl(mock2.clone());
+
+            let cancel_opening_fixture = CancelOpeningFixture::default_for_opening(opening_id);
+            cancel_opening_fixture.call_and_assert(Ok(OpeningCancelled {
+                number_of_unstaking_applications: 1,
+                number_of_deactivated_applications: 0,
+            }));
+
+            TestApplicationDeactivatedHandler::assert_deactivated_application(
+                application_id,
+                ApplicationDeactivationCause::OpeningCancelled,
+            );
+        })
+    });
+}
+
+#[test]
+fn cancel_opening_succeeds_with_single_unstaking_application_with_role_stake_checks() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = default_mock_for_creating_stake();
+            set_stake_handler_impl(mock.clone());
+
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.role_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_role_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+
+            let app_application_result = application_fixture.add_application();
+            assert!(app_application_result.is_ok());
+
+            let mock2 = default_mock_for_unstaking();
+            set_stake_handler_impl(mock2.clone());
+
+            let cancel_opening_fixture = CancelOpeningFixture::default_for_opening(opening_id);
+            cancel_opening_fixture.call_and_assert(Ok(OpeningCancelled {
+                number_of_unstaking_applications: 1,
+                number_of_deactivated_applications: 0,
+            }));
+        })
     });
 }

--- a/src/test/public_api/deactivate_application.rs
+++ b/src/test/public_api/deactivate_application.rs
@@ -1,17 +1,11 @@
-use super::*;
 use crate::mock::*;
-
-use add_application::AddApplicationFixture;
-use add_opening::AddOpeningFixture;
+use crate::test::public_api::*;
+use crate::test::*;
+use crate::ApplicationDeactivationCause;
 
 /*
 Not covered:
 - application content checks: deactivation in future blocks
-- ApplicationDeactivatedHandler
-
-- staking state checks:
-i.application.active_role_staking_id;
-ii.application.active_application_staking_id;
 */
 
 pub struct DeactivateApplicationFixture {
@@ -66,27 +60,40 @@ impl DeactivateApplicationFixture {
         let actual_application_state = <ApplicationById<Test>>::get(self.application_id);
 
         let expected_application_state = if deactivate_application_result.is_ok() {
-            Application {
-                stage: ApplicationStage::Inactive {
-                    deactivation_initiated: 1,
-                    deactivated: 1,
-                    cause: ApplicationDeactivationCause::External,
-                },
-                ..old_application_state
+            if old_application_state
+                .active_application_staking_id
+                .is_some()
+                || old_application_state.active_role_staking_id.is_some()
+            {
+                Application {
+                    stage: ApplicationStage::Unstaking {
+                        deactivation_initiated: 1,
+                        cause: ApplicationDeactivationCause::External,
+                    },
+                    ..old_application_state
+                }
+            } else {
+                Application {
+                    stage: ApplicationStage::Inactive {
+                        deactivation_initiated: 1,
+                        deactivated: 1,
+                        cause: ApplicationDeactivationCause::External,
+                    },
+                    ..old_application_state
+                }
             }
         } else {
             old_application_state
         };
 
         assert_eq!(expected_application_state, actual_application_state);
-        //       debug_print(new_application_state);
     }
 
     fn assert_opening_content(
         &self,
         opening_id: OpeningId,
         old_opening: Opening<Balance, BlockNumber, ApplicationId>,
-        add_application_result: Result<(), DeactivateApplicationError>,
+        actual_result: Result<(), DeactivateApplicationError>,
     ) {
         // invalid opening stages are not supported
 
@@ -108,10 +115,18 @@ impl DeactivateApplicationFixture {
             if let ActiveOpeningStage::AcceptingApplications { .. } = stage {
                 let mut expected_active_application_count = active_application_count;
                 let mut expected_deactivated_application_count = deactivated_application_count;
+                let mut expected_unstaking_application_count = unstaking_application_count;
 
-                if add_application_result.is_ok() {
+                if actual_result.is_ok() {
                     expected_active_application_count -= 1;
-                    expected_deactivated_application_count += 1;
+
+                    if old_opening.application_staking_policy.is_some()
+                        || old_opening.role_staking_policy.is_some()
+                    {
+                        expected_unstaking_application_count += 1;
+                    } else {
+                        expected_deactivated_application_count += 1;
+                    }
                 }
                 let expected_opening = Opening {
                     stage: OpeningStage::Active {
@@ -120,7 +135,7 @@ impl DeactivateApplicationFixture {
                         },
                         applications_added,
                         active_application_count: expected_active_application_count,
-                        unstaking_application_count,
+                        unstaking_application_count: expected_unstaking_application_count,
                         deactivated_application_count: expected_deactivated_application_count,
                     },
                     ..old_opening
@@ -147,7 +162,7 @@ fn deactivate_application_succeeds() {
         let deactivate_application_fixture =
             DeactivateApplicationFixture::default_for_application_id(application_id);
 
-        deactivate_application_fixture.call_and_assert(Ok(()))
+        deactivate_application_fixture.call_and_assert(Ok(()));
     });
 }
 
@@ -290,5 +305,78 @@ fn deactivate_application_fails_with_too_short_role_unstaking_period_provided() 
         deactivate_application_fixture.call_and_assert(Err(
             DeactivateApplicationError::UnstakingPeriodTooShort(StakePurpose::Role),
         ))
+    });
+}
+
+#[test]
+fn deactivate_application_succeeds_with_application_stake_checks() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = default_mock_for_creating_stake();
+            set_stake_handler_impl(mock.clone());
+
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.application_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_application_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let deactivate_application_fixture =
+                DeactivateApplicationFixture::default_for_application_id(application_id);
+
+            let mock2 = default_mock_for_unstaking();
+            set_stake_handler_impl(mock2.clone());
+
+            deactivate_application_fixture.call_and_assert(Ok(()));
+
+            TestApplicationDeactivatedHandler::assert_deactivated_application(
+                application_id,
+                ApplicationDeactivationCause::External,
+            );
+        });
+    });
+}
+
+#[test]
+fn deactivate_application_succeeds_with_role_stake_checks() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = default_mock_for_creating_stake();
+            set_stake_handler_impl(mock.clone());
+
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.role_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_role_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let deactivate_application_fixture =
+                DeactivateApplicationFixture::default_for_application_id(application_id);
+
+            let mock2 = default_mock_for_unstaking();
+            set_stake_handler_impl(mock2.clone());
+
+            deactivate_application_fixture.call_and_assert(Ok(()))
+        });
     });
 }

--- a/src/test/public_api/ensure_can_add_application.rs
+++ b/src/test/public_api/ensure_can_add_application.rs
@@ -1,16 +1,8 @@
-use super::*;
 use crate::mock::*;
+use crate::test::*;
 
 use crate::hiring::*;
-use crate::test::add_application::AddApplicationFixture;
-use add_opening::{AddOpeningFixture, HUMAN_READABLE_TEXT};
 use rstd::collections::btree_set::BTreeSet;
-
-/*
-Not covered:
-- application deactivation
-- staking state checks
-*/
 
 #[test]
 fn ensure_can_add_application_fails_with_no_opening() {

--- a/src/test/public_api/mod.rs
+++ b/src/test/public_api/mod.rs
@@ -1,0 +1,50 @@
+mod add_application;
+mod add_opening;
+mod deactivate_application;
+
+mod begin_accepting_applications;
+mod begin_review;
+mod cancel_opening;
+mod ensure_can_add_application;
+mod fill_opening;
+mod on_finalize;
+mod unstaked;
+
+pub use add_application::AddApplicationFixture;
+pub use add_opening::{AddOpeningFixture, HUMAN_READABLE_TEXT};
+pub use deactivate_application::DeactivateApplicationFixture;
+
+use crate::mock::Test;
+use rstd::cell::RefCell;
+use rstd::collections::btree_map::BTreeMap;
+use rstd::rc::Rc;
+
+fn default_mock_for_creating_stake() -> Rc<RefCell<crate::MockStakeHandler<Test>>> {
+    let mut mock = crate::MockStakeHandler::<Test>::new();
+
+    mock.expect_stake().times(1).returning(|_, _| Ok(()));
+    mock.expect_create_stake().times(1).returning(|| 0);
+
+    Rc::new(rstd::cell::RefCell::new(mock))
+}
+
+fn default_mock_for_unstaking() -> Rc<RefCell<crate::MockStakeHandler<Test>>> {
+    let mut mock = crate::MockStakeHandler::<Test>::new();
+    mock.expect_stake_exists().returning(|_| true);
+
+    mock.expect_initiate_unstaking()
+        .times(1)
+        .returning(|_, _| Ok(()));
+
+    mock.expect_get_stake().returning(|_| stake::Stake {
+        created: 1,
+        staking_status: stake::StakingStatus::Staked(stake::StakedState {
+            staked_amount: 100,
+            staked_status: stake::StakedStatus::Normal,
+            next_slash_id: 0,
+            ongoing_slashes: BTreeMap::new(),
+        }),
+    });
+
+    Rc::new(RefCell::new(mock))
+}

--- a/src/test/public_api/on_finalize.rs
+++ b/src/test/public_api/on_finalize.rs
@@ -1,8 +1,6 @@
-use super::*;
 use crate::mock::*;
+use crate::test::*;
 
-use add_application::AddApplicationFixture;
-use add_opening::AddOpeningFixture;
 use runtime_primitives::traits::{OnFinalize, OnInitialize};
 
 // Recommendation from Parity on testing on_finalize

--- a/src/test/public_api/unstaked.rs
+++ b/src/test/public_api/unstaked.rs
@@ -1,17 +1,6 @@
-use super::*;
 use crate::mock::*;
-
-use add_application::AddApplicationFixture;
-use add_opening::AddOpeningFixture;
-
-/*
-Not covered:
-- ApplicationDeactivatedHandler
-
-- staking state checks:
-i.application.active_role_staking_id;
-ii.application.active_application_staking_id;
-*/
+use crate::test::public_api::*;
+use crate::test::*;
 
 pub struct UnstakedFixture {
     pub opening_id: OpeningId,
@@ -125,7 +114,7 @@ impl UnstakedFixture {
 }
 
 #[test]
-fn unstaked_returns_existent_stake_id() {
+fn unstaked_returns_non_existent_stake_id() {
     build_test_externalities().execute_with(|| {
         let unstaked_fixture = UnstakedFixture {
             opening_id: 0,
@@ -155,11 +144,13 @@ fn unstaked_returns_application_is_not_unstaking() {
             Some(stake::NegativeImbalance::<Test>::new(100));
         let app_application_result = application_fixture.add_application();
         let application_id = app_application_result.unwrap().application_id_added;
+        let application = <ApplicationById<Test>>::get(application_id);
+        let stake_id = application.active_application_staking_id.unwrap();
 
         let unstaked_fixture = UnstakedFixture {
             opening_id,
             application_id,
-            stake_id: 0,
+            stake_id,
         };
 
         unstaked_fixture.call_and_assert(UnstakedResult::ApplicationIsNotUnstaking);
@@ -206,10 +197,13 @@ fn unstaked_returns_unstaking_in_progress() {
 
         assert!(application_fixture.add_application().is_ok());
 
+        let application = <ApplicationById<Test>>::get(first_application_id);
+        let stake_id = application.active_application_staking_id.unwrap();
+
         let unstaked_fixture = UnstakedFixture {
             opening_id,
             application_id: first_application_id,
-            stake_id: 0,
+            stake_id,
         };
 
         unstaked_fixture.call_and_assert(UnstakedResult::UnstakingInProgress);
@@ -246,10 +240,61 @@ fn unstaked_returns_unstaked() {
 
         assert!(application_fixture.add_application().is_ok());
 
+        let application = <ApplicationById<Test>>::get(first_application_id);
+        let stake_id = application.active_application_staking_id.unwrap();
+
         let unstaked_fixture = UnstakedFixture {
             opening_id,
             application_id: first_application_id,
-            stake_id: 0,
+            stake_id,
+        };
+
+        unstaked_fixture.call_and_assert(UnstakedResult::Unstaked);
+
+        TestApplicationDeactivatedHandler::assert_deactivated_application(
+            first_application_id,
+            ApplicationDeactivationCause::CrowdedOut,
+        );
+    });
+}
+
+#[test]
+fn unstaked_returns_unstaked_with_stake_checks() {
+    build_test_externalities().execute_with(|| {
+        let mut opening_fixture = AddOpeningFixture::default();
+        opening_fixture.application_rationing_policy = Some(hiring::ApplicationRationingPolicy {
+            max_active_applicants: 1,
+        });
+        opening_fixture.application_staking_policy = Some(StakingPolicy {
+            amount: 100,
+            amount_mode: StakingAmountLimitMode::AtLeast,
+            crowded_out_unstaking_period_length: None,
+            review_period_expired_unstaking_period_length: None,
+        });
+
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        application_fixture.opt_application_stake_imbalance =
+            Some(stake::NegativeImbalance::<Test>::new(100));
+
+        let app_application_result = application_fixture.add_application();
+        assert!(app_application_result.is_ok());
+        let first_application_id = app_application_result.unwrap().application_id_added;
+
+        application_fixture.opt_application_stake_imbalance =
+            Some(stake::NegativeImbalance::<Test>::new(101));
+
+        assert!(application_fixture.add_application().is_ok());
+
+        let application = <ApplicationById<Test>>::get(first_application_id);
+        let stake_id = application.active_application_staking_id.unwrap();
+
+        let unstaked_fixture = UnstakedFixture {
+            opening_id,
+            application_id: first_application_id,
+            stake_id,
         };
 
         unstaked_fixture.call_and_assert(UnstakedResult::Unstaked);

--- a/src/test/staking_module/get_opt_stake_amount.rs
+++ b/src/test/staking_module/get_opt_stake_amount.rs
@@ -1,0 +1,83 @@
+use super::*;
+use crate::mock::*;
+
+use mockall::predicate::*;
+
+#[test]
+fn get_opt_stake_amount_succeeds_with_empty_stake_id() {
+    build_test_externalities().execute_with(|| {
+        let no_stake = Hiring::get_opt_stake_amount(None);
+
+        assert_eq!(no_stake, 0)
+    })
+}
+
+#[test]
+#[should_panic]
+fn get_opt_stake_amount_panics_with_non_existing_stake() {
+    build_test_externalities().execute_with(|| {
+        Hiring::get_opt_stake_amount(Some(0));
+    });
+}
+
+#[test]
+#[should_panic]
+fn get_opt_stake_amount_panics_with_incorrect_stake_status() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_stake_exists()
+                    .with(eq(0))
+                    .times(1)
+                    .returning(|_| true);
+
+                mock.expect_get_stake()
+                    .with(eq(0))
+                    .times(1)
+                    .returning(|_| stake::Stake {
+                        created: 1,
+                        staking_status: stake::StakingStatus::NotStaked,
+                    });
+
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            Hiring::get_opt_stake_amount(Some(0));
+        })
+    })
+}
+
+#[test]
+fn get_opt_stake_amount_succeeds_with_existing_stake() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_stake_exists()
+                    .with(eq(0))
+                    .times(1)
+                    .returning(|_| true);
+
+                mock.expect_get_stake()
+                    .with(eq(0))
+                    .times(1)
+                    .returning(|_| stake::Stake {
+                        created: 1,
+                        staking_status: stake::StakingStatus::Staked(stake::StakedState {
+                            staked_amount: 100,
+                            staked_status: stake::StakedStatus::Normal,
+                            next_slash_id: 0,
+                            ongoing_slashes: BTreeMap::new(),
+                        }),
+                    });
+
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock.clone());
+
+            assert_eq!(Hiring::get_opt_stake_amount(Some(0)), 100);
+        })
+    });
+}

--- a/src/test/staking_module/infallible_stake_initiation_on_application.rs
+++ b/src/test/staking_module/infallible_stake_initiation_on_application.rs
@@ -1,0 +1,72 @@
+use super::*;
+use crate::mock::*;
+
+#[test]
+#[should_panic]
+fn infallible_stake_initiation_on_application_panics_on_existed_stake() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_create_stake().times(1).returning(|| 10);
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            let application_id = 10;
+            <ApplicationIdByStakingId<Test>>::insert(10, application_id);
+
+            Hiring::infallible_stake_initiation_on_application(
+                stake::NegativeImbalance::<Test>::new(100),
+                &application_id,
+            );
+        });
+    });
+}
+
+#[test]
+#[should_panic]
+fn infallible_stake_initiation_on_application_panics_on_unsuccessful_staking() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_create_stake().times(1).returning(|| 10);
+                mock.expect_stake()
+                    .times(1)
+                    .returning(|_, _| Err(StakeActionError::StakeNotFound));
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            let application_id = 10;
+            Hiring::infallible_stake_initiation_on_application(
+                stake::NegativeImbalance::<Test>::new(100),
+                &application_id,
+            );
+        });
+    });
+}
+
+#[test]
+fn infallible_stake_initiation_on_application_succeeds() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_create_stake().times(1).returning(|| 10);
+                mock.expect_stake().times(1).returning(|_, _| Ok(()));
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            let application_id = 10;
+            let staking_result = Hiring::infallible_stake_initiation_on_application(
+                stake::NegativeImbalance::<Test>::new(100),
+                &application_id,
+            );
+
+            assert_eq!(staking_result, 10);
+        });
+    });
+}

--- a/src/test/staking_module/initiate_application_deactivations.rs
+++ b/src/test/staking_module/initiate_application_deactivations.rs
@@ -1,0 +1,111 @@
+use super::*;
+use crate::mock::*;
+
+type ApplicationMap = BTreeMap<ApplicationId, hiring::Application<OpeningId, BlockNumber, StakeId>>;
+
+struct InitiateApplicationDeactivationsFixture {
+    pub applications: ApplicationMap,
+    pub application_stake_unstaking_period: Option<BlockNumber>,
+    pub role_stake_unstaking_period: Option<BlockNumber>,
+    pub cause: ApplicationDeactivationCause,
+}
+
+impl InitiateApplicationDeactivationsFixture {
+    fn default_for_applications(
+        applications: ApplicationMap,
+    ) -> InitiateApplicationDeactivationsFixture {
+        InitiateApplicationDeactivationsFixture {
+            applications,
+            application_stake_unstaking_period: None,
+            role_stake_unstaking_period: None,
+            cause: ApplicationDeactivationCause::External,
+        }
+    }
+
+    fn initiate_application_deactivations(&self) -> ApplicationsDeactivationsInitiationResult {
+        Hiring::initiate_application_deactivations(
+            &self.applications,
+            self.application_stake_unstaking_period,
+            self.role_stake_unstaking_period,
+            self.cause,
+        )
+    }
+
+    fn call_and_assert(&self, expected_result: ApplicationsDeactivationsInitiationResult) {
+        let actual_result = self.initiate_application_deactivations();
+
+        assert_eq!(expected_result, actual_result);
+    }
+}
+
+#[test]
+fn initiate_application_deactivations_succeeds_with_deactivated_result() {
+    build_test_externalities().execute_with(|| {
+        let opening_fixture = AddOpeningFixture::default();
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        let app_application_result = application_fixture.add_application();
+        let application_id = app_application_result.unwrap().application_id_added;
+
+        let application = <ApplicationById<Test>>::get(application_id);
+
+        let mut applications = ApplicationMap::new();
+        applications.insert(application_id, application);
+
+        let iad_fixture =
+            InitiateApplicationDeactivationsFixture::default_for_applications(applications);
+
+        iad_fixture.call_and_assert(ApplicationsDeactivationsInitiationResult {
+            number_of_deactivated_applications: 1,
+            number_of_unstaking_applications: 0,
+        });
+    });
+}
+
+#[test]
+fn initiate_application_deactivations_succeeds_with_unstaking_result() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.application_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_application_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let application = <ApplicationById<Test>>::get(application_id);
+
+            let mut applications = ApplicationMap::new();
+            applications.insert(application_id, application);
+
+            let iad_fixture =
+                InitiateApplicationDeactivationsFixture::default_for_applications(applications);
+
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_initiate_unstaking()
+                    .times(1)
+                    .returning(|_, _| Ok(()));
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            iad_fixture.call_and_assert(ApplicationsDeactivationsInitiationResult {
+                number_of_deactivated_applications: 0,
+                number_of_unstaking_applications: 1,
+            });
+        });
+    });
+}

--- a/src/test/staking_module/mod.rs
+++ b/src/test/staking_module/mod.rs
@@ -1,0 +1,8 @@
+mod get_opt_stake_amount;
+mod infallible_stake_initiation_on_application;
+mod initiate_application_deactivations;
+mod opt_infallible_unstake;
+mod try_to_initiate_application_deactivation;
+mod would_application_get_added;
+
+use super::*;

--- a/src/test/staking_module/opt_infallible_unstake.rs
+++ b/src/test/staking_module/opt_infallible_unstake.rs
@@ -1,0 +1,39 @@
+use super::*;
+use crate::mock::*;
+
+#[test]
+fn opt_infallible_unstake_succeeds_with_empty_stake() {
+    build_test_externalities().execute_with(|| {
+        let unstake_result = Hiring::opt_infallible_unstake(None, None);
+
+        assert_eq!(unstake_result, false);
+    });
+}
+
+#[test]
+#[should_panic]
+fn opt_infallible_unstake_panics_with_invalid_stake() {
+    build_test_externalities().execute_with(|| {
+        Hiring::opt_infallible_unstake(Some(10), None);
+    });
+}
+
+#[test]
+fn opt_infallible_unstake_succeeds() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_initiate_unstaking()
+                    .times(1)
+                    .returning(|_, _| Ok(()));
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            let unstake_result = Hiring::opt_infallible_unstake(Some(10), Some(10));
+
+            assert_eq!(unstake_result, true);
+        });
+    });
+}

--- a/src/test/staking_module/try_to_initiate_application_deactivation.rs
+++ b/src/test/staking_module/try_to_initiate_application_deactivation.rs
@@ -1,0 +1,391 @@
+use super::*;
+use crate::mock::*;
+
+struct TryToInitiateApplicationDeactivationFixture<'a> {
+    pub application: &'a Application<OpeningId, BlockNumber, StakeId>,
+    pub application_id: ApplicationId,
+    pub application_stake_unstaking_period: Option<BlockNumber>,
+    pub role_stake_unstaking_period: Option<BlockNumber>,
+    pub cause: hiring::ApplicationDeactivationCause,
+}
+
+impl<'a> TryToInitiateApplicationDeactivationFixture<'a> {
+    pub fn default_for_application(
+        application_id: ApplicationId,
+        application: &'a Application<OpeningId, BlockNumber, StakeId>,
+    ) -> TryToInitiateApplicationDeactivationFixture<'a> {
+        TryToInitiateApplicationDeactivationFixture {
+            application,
+            application_id,
+            application_stake_unstaking_period: None,
+            role_stake_unstaking_period: None,
+            cause: ApplicationDeactivationCause::NotHired,
+        }
+    }
+
+    fn call_and_assert(&self, expected_result: ApplicationDeactivationInitiationResult) {
+        let old_application = <ApplicationById<Test>>::get(self.application_id);
+        let old_opening_state = <OpeningById<Test>>::get(old_application.opening_id);
+
+        let actual_result = self.try_to_initiate_application_deactivation();
+
+        assert_eq!(expected_result, actual_result);
+
+        self.assert_application_content(old_application.clone(), actual_result.clone());
+
+        self.assert_opening_content(old_application.opening_id, old_opening_state, actual_result);
+    }
+
+    fn try_to_initiate_application_deactivation(&self) -> ApplicationDeactivationInitiationResult {
+        Hiring::try_to_initiate_application_deactivation(
+            self.application,
+            self.application_id,
+            self.application_stake_unstaking_period,
+            self.role_stake_unstaking_period,
+            self.cause,
+        )
+    }
+
+    fn assert_application_content(
+        &self,
+        old_application_state: Application<OpeningId, BlockNumber, StakeId>,
+        result: ApplicationDeactivationInitiationResult,
+    ) {
+        let actual_application_state = <ApplicationById<Test>>::get(self.application_id);
+
+        let expected_application_state = match result {
+            ApplicationDeactivationInitiationResult::Deactivated => Application {
+                stage: ApplicationStage::Inactive {
+                    deactivation_initiated: 1,
+                    deactivated: 1,
+                    cause: self.cause,
+                },
+                ..old_application_state
+            },
+            ApplicationDeactivationInitiationResult::Unstaking => Application {
+                stage: ApplicationStage::Unstaking {
+                    deactivation_initiated: 1,
+                    cause: self.cause,
+                },
+                ..old_application_state
+            },
+            ApplicationDeactivationInitiationResult::Ignored => old_application_state,
+        };
+
+        assert_eq!(expected_application_state, actual_application_state);
+    }
+
+    fn assert_opening_content(
+        &self,
+        opening_id: OpeningId,
+        old_opening: Opening<Balance, BlockNumber, ApplicationId>,
+        result: ApplicationDeactivationInitiationResult,
+    ) {
+        // invalid opening stages are not supported
+
+        // check for opening existence
+        if !<OpeningById<Test>>::exists(opening_id) {
+            return;
+        }
+
+        // check only for active opening
+        if let OpeningStage::Active {
+            stage,
+            applications_added,
+            active_application_count,
+            unstaking_application_count,
+            deactivated_application_count,
+        } = old_opening.stage
+        {
+            // check only for accepting application stage
+            if let ActiveOpeningStage::AcceptingApplications { .. } = stage {
+                let mut expected_active_application_count = active_application_count;
+                let mut expected_deactivated_application_count = deactivated_application_count;
+                let mut expected_unstaking_application_count = unstaking_application_count;
+
+                match result {
+                    ApplicationDeactivationInitiationResult::Deactivated => {
+                        expected_active_application_count -= 1;
+                        expected_deactivated_application_count += 1;
+                    }
+                    ApplicationDeactivationInitiationResult::Unstaking => {
+                        expected_active_application_count -= 1;
+                        expected_unstaking_application_count += 1;
+                    }
+                    ApplicationDeactivationInitiationResult::Ignored => {}
+                }
+
+                let expected_opening = Opening {
+                    stage: OpeningStage::Active {
+                        stage: ActiveOpeningStage::AcceptingApplications {
+                            started_accepting_applicants_at_block: 1,
+                        },
+                        applications_added,
+                        active_application_count: expected_active_application_count,
+                        unstaking_application_count: expected_unstaking_application_count,
+                        deactivated_application_count: expected_deactivated_application_count,
+                    },
+                    ..old_opening
+                };
+
+                let new_opening_state = <OpeningById<Test>>::get(opening_id);
+                assert_eq!(new_opening_state, expected_opening);
+            }
+        }
+    }
+}
+
+#[test]
+fn try_to_initiate_application_deactivation_succeeds_with_ignored_result() {
+    build_test_externalities().execute_with(|| {
+        let opening_fixture = AddOpeningFixture::default();
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        let app_application_result = application_fixture.add_application();
+        let application_id = app_application_result.unwrap().application_id_added;
+
+        let deactivate_application_fixture =
+            DeactivateApplicationFixture::default_for_application_id(application_id);
+
+        assert!(deactivate_application_fixture
+            .deactivate_application()
+            .is_ok());
+
+        let application = <ApplicationById<Test>>::get(application_id);
+        let ttiad_fixture = TryToInitiateApplicationDeactivationFixture::default_for_application(
+            application_id,
+            &application,
+        );
+
+        ttiad_fixture.call_and_assert(ApplicationDeactivationInitiationResult::Ignored);
+    });
+}
+
+#[test]
+#[should_panic]
+fn try_to_initiate_application_deactivation_panics_because_of_not_active_opening() {
+    build_test_externalities().execute_with(|| {
+        let opening_fixture = AddOpeningFixture::default();
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        let app_application_result = application_fixture.add_application();
+        let application_id = app_application_result.unwrap().application_id_added;
+
+        let application = <ApplicationById<Test>>::get(application_id);
+
+        // provide incorrect opening (invalid stage)
+        let mut opening = <OpeningById<Test>>::get(opening_id);
+        opening.stage = OpeningStage::WaitingToBegin { begins_at_block: 0 };
+        <OpeningById<Test>>::insert(opening_id, opening);
+
+        let ttiad_fixture = TryToInitiateApplicationDeactivationFixture::default_for_application(
+            application_id,
+            &application,
+        );
+
+        ttiad_fixture.call_and_assert(ApplicationDeactivationInitiationResult::Ignored);
+    });
+}
+
+#[test]
+#[should_panic]
+fn try_to_initiate_application_deactivation_panics_because_of_opening_with_no_applications() {
+    build_test_externalities().execute_with(|| {
+        let opening_fixture = AddOpeningFixture::default();
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        let app_application_result = application_fixture.add_application();
+        let application_id = app_application_result.unwrap().application_id_added;
+
+        let application = <ApplicationById<Test>>::get(application_id);
+
+        // provide incorrect opening (no applications)
+        let add_opening_result = opening_fixture.add_opening();
+        let new_opening_id = add_opening_result.unwrap();
+        let new_opening = <OpeningById<Test>>::get(new_opening_id);
+        <OpeningById<Test>>::insert(opening_id, new_opening);
+
+        let ttiad_fixture = TryToInitiateApplicationDeactivationFixture::default_for_application(
+            application_id,
+            &application,
+        );
+
+        ttiad_fixture.call_and_assert(ApplicationDeactivationInitiationResult::Ignored);
+    });
+}
+
+#[test]
+fn try_to_initiate_application_deactivation_succeeds_with_deactivated_result() {
+    build_test_externalities().execute_with(|| {
+        let opening_fixture = AddOpeningFixture::default();
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        let app_application_result = application_fixture.add_application();
+        let application_id = app_application_result.unwrap().application_id_added;
+
+        let application = <ApplicationById<Test>>::get(application_id);
+
+        let ttiad_fixture = TryToInitiateApplicationDeactivationFixture::default_for_application(
+            application_id,
+            &application,
+        );
+
+        ttiad_fixture.call_and_assert(ApplicationDeactivationInitiationResult::Deactivated);
+    });
+}
+
+#[test]
+fn try_to_initiate_application_deactivation_succeeds_with_single_application_unstaking() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.application_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_application_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let application = <ApplicationById<Test>>::get(application_id);
+
+            let ttiad_fixture =
+                TryToInitiateApplicationDeactivationFixture::default_for_application(
+                    application_id,
+                    &application,
+                );
+
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_initiate_unstaking()
+                    .times(1)
+                    .returning(|_, _| Ok(()));
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            ttiad_fixture.call_and_assert(ApplicationDeactivationInitiationResult::Unstaking);
+        });
+    });
+}
+
+#[test]
+fn try_to_initiate_application_deactivation_succeeds_with_application_and_role_unstaking() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.application_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+            opening_fixture.role_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_application_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+            application_fixture.opt_role_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let application = <ApplicationById<Test>>::get(application_id);
+
+            let ttiad_fixture =
+                TryToInitiateApplicationDeactivationFixture::default_for_application(
+                    application_id,
+                    &application,
+                );
+
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_initiate_unstaking()
+                    .times(2)
+                    .returning(|_, _| Ok(()));
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            ttiad_fixture.call_and_assert(ApplicationDeactivationInitiationResult::Unstaking);
+        });
+    });
+}
+
+#[test]
+fn try_to_initiate_application_deactivation_succeeds_hired_cause_and_application_only_unstaking() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.application_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+            opening_fixture.role_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_application_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+            application_fixture.opt_role_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let application = <ApplicationById<Test>>::get(application_id);
+
+            let mut ttiad_fixture =
+                TryToInitiateApplicationDeactivationFixture::default_for_application(
+                    application_id,
+                    &application,
+                );
+            ttiad_fixture.cause = ApplicationDeactivationCause::Hired;
+
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+                mock.expect_initiate_unstaking()
+                    .times(1)
+                    .returning(|_, _| Ok(()));
+                Rc::new(RefCell::new(mock))
+            };
+            set_stake_handler_impl(mock);
+
+            ttiad_fixture.call_and_assert(ApplicationDeactivationInitiationResult::Unstaking);
+        });
+    });
+}

--- a/src/test/staking_module/would_application_get_added.rs
+++ b/src/test/staking_module/would_application_get_added.rs
@@ -1,0 +1,221 @@
+use super::*;
+use crate::mock::*;
+
+#[derive(Default)]
+struct WouldApplicationGetAddedFixture {
+    possible_opening_application_rationing_policy: Option<ApplicationRationingPolicy>,
+    opening_applicants: BTreeSet<ApplicationId>,
+    opt_role_stake_balance: Option<Balance>,
+    opt_application_stake_balance: Option<Balance>,
+}
+
+impl WouldApplicationGetAddedFixture {
+    fn call_and_assert(&self, expected_result: ApplicationWouldGetAddedEvaluation<Test>) {
+        let wagaf_result = self.would_application_get_added();
+
+        assert_eq!(wagaf_result, expected_result);
+    }
+
+    fn would_application_get_added(&self) -> ApplicationWouldGetAddedEvaluation<Test> {
+        Hiring::would_application_get_added(
+            &self.possible_opening_application_rationing_policy,
+            &self.opening_applicants,
+            &self.opt_role_stake_balance,
+            &self.opt_application_stake_balance,
+        )
+    }
+}
+
+#[test]
+fn would_application_get_added_with_no_rationing_policy() {
+    build_test_externalities().execute_with(|| {
+        let wagaf = WouldApplicationGetAddedFixture::default();
+
+        wagaf.call_and_assert(ApplicationWouldGetAddedEvaluation::Yes(
+            ApplicationAddedSuccess::Unconditionally,
+        ));
+    });
+}
+
+#[test]
+fn would_application_get_added_with_zero_opening_applicants() {
+    build_test_externalities().execute_with(|| {
+        let mut wagaf = WouldApplicationGetAddedFixture::default();
+        wagaf.possible_opening_application_rationing_policy =
+            Some(hiring::ApplicationRationingPolicy {
+                max_active_applicants: 1,
+            });
+
+        wagaf.call_and_assert(ApplicationWouldGetAddedEvaluation::Yes(
+            ApplicationAddedSuccess::Unconditionally,
+        ));
+    });
+}
+
+#[test]
+fn would_application_get_added_with_too_low_stake() {
+    build_test_externalities().execute_with(|| {
+        let mut opening_fixture = AddOpeningFixture::default();
+        opening_fixture.application_rationing_policy = Some(hiring::ApplicationRationingPolicy {
+            max_active_applicants: 1,
+        });
+        opening_fixture.application_staking_policy = Some(StakingPolicy {
+            amount: 100,
+            amount_mode: StakingAmountLimitMode::AtLeast,
+            crowded_out_unstaking_period_length: None,
+            review_period_expired_unstaking_period_length: None,
+        });
+
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        application_fixture.opt_application_stake_imbalance =
+            Some(stake::NegativeImbalance::<Test>::new(100));
+
+        let app_application_result = application_fixture.add_application();
+        let application_id = app_application_result.unwrap().application_id_added;
+
+        let mut wagaf = WouldApplicationGetAddedFixture::default();
+        wagaf.possible_opening_application_rationing_policy =
+            Some(hiring::ApplicationRationingPolicy {
+                max_active_applicants: 1,
+            });
+        wagaf.opening_applicants.insert(application_id);
+        wagaf.opt_application_stake_balance = Some(99);
+
+        wagaf.call_and_assert(ApplicationWouldGetAddedEvaluation::No);
+    });
+}
+
+#[test]
+fn would_application_get_added_with_too_low_stake_with_mocks() {
+    handle_mock(|| {
+        build_test_externalities().execute_with(|| {
+            let mock = {
+                let mut mock = crate::MockStakeHandler::<Test>::new();
+
+                mock.expect_stake().times(1).returning(|_, _| Ok(()));
+                mock.expect_stake_exists().times(2).returning(|_| true);
+                mock.expect_create_stake().times(1).returning(|| 0);
+                mock.expect_get_stake().returning(|_| stake::Stake {
+                    created: 1,
+                    staking_status: stake::StakingStatus::Staked(stake::StakedState {
+                        staked_amount: 101,
+                        staked_status: stake::StakedStatus::Normal,
+                        next_slash_id: 0,
+                        ongoing_slashes: BTreeMap::new(),
+                    }),
+                });
+
+                Rc::new(rstd::cell::RefCell::new(mock))
+            };
+
+            set_stake_handler_impl(mock.clone());
+
+            let mut opening_fixture = AddOpeningFixture::default();
+            opening_fixture.application_rationing_policy =
+                Some(hiring::ApplicationRationingPolicy {
+                    max_active_applicants: 1,
+                });
+            opening_fixture.application_staking_policy = Some(StakingPolicy {
+                amount: 100,
+                amount_mode: StakingAmountLimitMode::AtLeast,
+                crowded_out_unstaking_period_length: None,
+                review_period_expired_unstaking_period_length: None,
+            });
+
+            let add_opening_result = opening_fixture.add_opening();
+            let opening_id = add_opening_result.unwrap();
+
+            let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+            application_fixture.opt_application_stake_imbalance =
+                Some(stake::NegativeImbalance::<Test>::new(100));
+
+            let app_application_result = application_fixture.add_application();
+            let application_id = app_application_result.unwrap().application_id_added;
+
+            let mut wagaf = WouldApplicationGetAddedFixture::default();
+            wagaf.possible_opening_application_rationing_policy =
+                Some(hiring::ApplicationRationingPolicy {
+                    max_active_applicants: 1,
+                });
+            wagaf.opening_applicants.insert(application_id);
+            wagaf.opt_application_stake_balance = Some(99);
+
+            wagaf.call_and_assert(ApplicationWouldGetAddedEvaluation::No);
+        });
+    });
+}
+
+#[test]
+fn would_application_get_added_with_crowding_out() {
+    build_test_externalities().execute_with(|| {
+        let mut opening_fixture = AddOpeningFixture::default();
+        opening_fixture.application_rationing_policy = Some(hiring::ApplicationRationingPolicy {
+            max_active_applicants: 1,
+        });
+        opening_fixture.application_staking_policy = Some(StakingPolicy {
+            amount: 100,
+            amount_mode: StakingAmountLimitMode::AtLeast,
+            crowded_out_unstaking_period_length: None,
+            review_period_expired_unstaking_period_length: None,
+        });
+
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        application_fixture.opt_application_stake_imbalance =
+            Some(stake::NegativeImbalance::<Test>::new(100));
+
+        let app_application_result = application_fixture.add_application();
+        let application_id = app_application_result.unwrap().application_id_added;
+
+        let mut wagaf = WouldApplicationGetAddedFixture::default();
+        wagaf.possible_opening_application_rationing_policy =
+            Some(hiring::ApplicationRationingPolicy {
+                max_active_applicants: 1,
+            });
+        wagaf.opening_applicants.insert(application_id);
+        wagaf.opt_application_stake_balance = Some(101);
+
+        wagaf.call_and_assert(ApplicationWouldGetAddedEvaluation::Yes(
+            ApplicationAddedSuccess::CrowdsOutExistingApplication(application_id),
+        ));
+    });
+}
+#[test]
+#[should_panic]
+fn would_application_get_added_panics_with_bad_params() {
+    build_test_externalities().execute_with(|| {
+        let mut opening_fixture = AddOpeningFixture::default();
+        opening_fixture.application_rationing_policy = Some(hiring::ApplicationRationingPolicy {
+            max_active_applicants: 1,
+        });
+        opening_fixture.application_staking_policy = Some(StakingPolicy {
+            amount: 100,
+            amount_mode: StakingAmountLimitMode::AtLeast,
+            crowded_out_unstaking_period_length: None,
+            review_period_expired_unstaking_period_length: None,
+        });
+
+        let add_opening_result = opening_fixture.add_opening();
+        let opening_id = add_opening_result.unwrap();
+
+        let mut application_fixture = AddApplicationFixture::default_for_opening(opening_id);
+        application_fixture.opt_application_stake_imbalance =
+            Some(stake::NegativeImbalance::<Test>::new(100));
+
+        assert!(application_fixture.add_application().is_ok());
+
+        let mut wagaf = WouldApplicationGetAddedFixture::default();
+        wagaf.possible_opening_application_rationing_policy =
+            Some(hiring::ApplicationRationingPolicy {
+                max_active_applicants: 0,
+            });
+        wagaf.opt_application_stake_balance = Some(100);
+
+        wagaf.would_application_get_added();
+    });
+}


### PR DESCRIPTION
This is a combined PR from several smaller PRs in my fork (shamil-gadelshin/substrate-hiring-module):

1. PR for the test of Mokhtar's bugfix. Actually I covered not only Mokhtar's fixes but whole 'try_to_initiate_application_deactivation()'.
https://github.com/shamil-gadelshin/substrate-hiring-module/pull/5

2. Final test pack for hiring with previously missing tests, including tests for ApplicationDeactivatedHandler.
https://github.com/shamil-gadelshin/substrate-hiring-module/pull/6

3. Simplification of mock-solution (removing 'mocktopus' dependency)
https://github.com/shamil-gadelshin/substrate-hiring-module/pull/7)


Runtime definition needs minor update:
```
impl hiring::Trait for Runtime {
    type OpeningId = u64;
    type ApplicationId = u64;
    type ApplicationDeactivatedHandler = (); // TODO - what needs to happen?
    type StakeHandlerProvider = hiring::Module<Self>;
}
```