### PR TITLE
Fix/fill opening/applications for opening only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.39.0
+  - 1.41.1
 
 cache:
   - cargo

--- a/src/test/public_api/fill_opening.rs
+++ b/src/test/public_api/fill_opening.rs
@@ -461,7 +461,7 @@ fn fill_opening_fails_with_application_to_wrong_opening() {
         // opening 1 being review
         assert!(Hiring::begin_review(opening_id).is_ok());
 
-        // fill opening 1 with application made to opening  (which should fail)
+        // fill opening 1 with application made to opening 2 (which should fail)
         let mut fill_opening_fixture = FillOpeningFixture::default_for_opening(opening_id);
         let mut apps = BTreeSet::new();
         apps.insert(application_id);


### PR DESCRIPTION
Reject attempt to fill opening with applications made to different opening.

I had to update travis to use latest rustc to get around compiler error for parity codec package.